### PR TITLE
Fix bundle namespace in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Stoakes\\Bundle\\RoutingConverterBundle\\": ""
+      "Stoakes\\RoutingConverterBundle\\": ""
     },
     "exclude-from-classmap": [
       "/Tests/"


### PR DESCRIPTION
The bundle namespace in `composer.json` was `Stoakes\\Bundle\\RoutingConverterBundle\\` instead of `Stoakes\\RoutingConverterBundle\\`, so after installing the bundle, the autoload generated by composer was wrong and an exception was thrown by Symfony :

```
Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "StoakesRoutingConverterBundle" from namespace "Stoakes\RoutingConverterBundle".
Did you forget a "use" statement for another namespace? in [...]/app/AppKernel.php:30
```